### PR TITLE
cmd.exe from System32 for ia32 (Closes #6)

### DIFF
--- a/src/utils/machineId.ts
+++ b/src/utils/machineId.ts
@@ -3,7 +3,7 @@ import { hash } from './common';
 
 const platforms = {
   darwin: 'ioreg -rd1 -c IOPlatformExpertDevice',
-  ia32: '%windir%\\sysnative\\cmd.exe \/c %windir%\\System32\\REG ' +
+  ia32: '%windir%\\System32\\cmd.exe \/c %windir%\\System32\\REG ' +
   'QUERY HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography ' +
   '/v MachineGuid',
   x64: '%windir%\\System32\\REG ' +


### PR DESCRIPTION
Probably solves issue #6 by calling cmd.exe from %windir%\System32 instead of from the virtual folder %windir%\SysNative.

More on Windows WoW64 redirects https://docs.microsoft.com/en-us/windows/desktop/winprog64/file-system-redirector